### PR TITLE
chore: refactoring type test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "sinon-chai": "^4.0.1",
         "ts-mocha": "^11.1.0",
         "ts-node": "^10.9.2",
-        "tstyche": "^4.3.0",
+        "tstyche": "^5.0.0-beta.2",
         "typescript": "^5.5.4",
         "web-worker": "^1.5.0"
       }
@@ -1438,16 +1438,16 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-4.3.0.tgz",
-      "integrity": "sha512-X5mSVCivhCSDKHr9tWfCH0kmEo5cLApZILK5XfssTIirc9wEvcSYhCaixj5TSR/39cIC7U5TQD+wtGKsYh7nlw==",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-5.0.0-beta.2.tgz",
+      "integrity": "sha512-2ZOcV/JN4IB3KaS2JgYskkgtio+Dfj4mrIr/PcJ1hAGv0Zx0Lk8Hg73ztnehw5hJPLYtT187Gtw1FTMIF7Q+lw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=20.9"
+        "node": ">=20.12"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:unit && npm run test:types",
     "test:unit": "ts-mocha -n loader=ts-node/esm -p ./tsconfig.json --require ./tests/setup.ts ./tests/ut/**/*.test.ts",
     "test:watch": "ts-mocha -n loader=ts-node/esm -p ./tsconfig.json --require ./tests/setup.ts --watch --parallel --slow 100 ./tests/ut/**/*.test.ts",
-    "test:types": "tstyche ./tests"
+    "test:types": "tstyche"
   },
   "files": [
     "dist/**/*.js",
@@ -45,7 +45,7 @@
     "sinon-chai": "^4.0.1",
     "ts-mocha": "^11.1.0",
     "ts-node": "^10.9.2",
-    "tstyche": "^4.3.0",
+    "tstyche": "^5.0.0-beta.2",
     "typescript": "^5.5.4",
     "web-worker": "^1.5.0"
   },

--- a/src/misc/Queue.ts
+++ b/src/misc/Queue.ts
@@ -22,7 +22,7 @@ export class Queue<TItem> {
         return this.#tail++;
     }
 
-    dequeue() {
+    dequeue(): TItem {
         if (this.isEmpty) {
             throw new Error("Cannot dequeue from an empty queue.");
         }
@@ -31,7 +31,7 @@ export class Queue<TItem> {
         return item;
     }
 
-    peek() {
+    peek(): TItem {
         if (this.isEmpty) {
             throw new Error("Cannot peek on an empty queue.");
         }

--- a/src/workers.d.ts
+++ b/src/workers.d.ts
@@ -22,8 +22,8 @@ export type WorkerTasks<T extends Record<string, (...args: any) => any>> = {
 export type AsyncMessage<Tasks extends Record<string, (...args: any) => any>> = {
     task: keyof Tasks;
     workItemId: number;
-    cancelToken?: Token;
-    payload?: WorkerTasks<Tasks>[keyof Tasks]['payload'];
+    cancelToken?: Token | undefined;
+    payload?: WorkerTasks<Tasks>[keyof Tasks]['payload'] | undefined;
 };
 
 /**
@@ -32,7 +32,7 @@ export type AsyncMessage<Tasks extends Record<string, (...args: any) => any>> = 
 export type AsyncMessageUntyped = {
     workItemId: number;
     task: string;
-    cancelToken?: Token;
+    cancelToken?: Token | undefined;
     payload?: any;
 };
 

--- a/tests/typetests/index.test.ts
+++ b/tests/typetests/index.test.ts
@@ -45,12 +45,15 @@ describe("Type Tests", () => {
 
         type TaskTypes = WorkerTasks<TestTasks>;
         
-        expect<TaskTypes['add']['payload']>().type.toBe<{ a: number; b: number }>();
-        expect<TaskTypes['add']['return']>().type.toBe<number>();
-        expect<TaskTypes['greet']['payload']>().type.toBe<{ name: string }>();
-        expect<TaskTypes['greet']['return']>().type.toBe<string>();
-        expect<TaskTypes['noArgs']['payload']>().type.toBe<undefined>();
-        expect<TaskTypes['noArgs']['return']>().type.toBe<void>();
+        expect<Pick<TaskTypes, "add">>().type.toBe<{
+            add: { payload: { a: number; b: number }; return: number }
+        }>();
+        expect<Pick<TaskTypes, "greet">>().type.toBe<{
+            greet: { payload: { name: string }; return: string }
+        }>();
+        expect<Pick<TaskTypes, "noArgs">>().type.toBe<{ 
+            noArgs: { payload: undefined; return: void }
+        }>();
     });
 
     test("AsyncMessage should have correct structure", () => {
@@ -58,23 +61,21 @@ describe("Type Tests", () => {
             compute: (args: { value: number }) => string;
         };
 
-        type Message = AsyncMessage<TestTasks>;
-        
-        expect<Message['task']>().type.toBe<keyof TestTasks>();
-        expect<Message['workItemId']>().type.toBe<number>();
-        expect<Message['cancelToken']>().type.toBe<Token | undefined>();
-        expect<Message['payload']>().type.toBe<{ value: number } | undefined>();
+        expect<AsyncMessage<TestTasks>>().type.toBe<{
+            task: "compute";
+            workItemId: number;
+            cancelToken?: Token | undefined;
+            payload?: { value: number } | undefined;
+        }>();
     });
 
     test("CancellationSource static methods should have correct signatures", () => {
         const token: Token = new Int32Array(1);
         
-        expect(CancellationSource.isSignaled).type.toBeCallableWith(token);
         expect(CancellationSource.isSignaled(token)).type.toBe<boolean>();
         
-        expect(CancellationSource.throwIfSignaled).type.toBeCallableWith(token);
-        expect(CancellationSource.throwIfSignaled).type.toBeCallableWith(undefined);
         expect(CancellationSource.throwIfSignaled(token)).type.toBe<void>();
+        expect(CancellationSource.throwIfSignaled(undefined)).type.toBe<void>();
     });
 
     test("Queue should not accept wrong types", () => {

--- a/tests/typetests/tsconfig.json
+++ b/tests/typetests/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ESNext",                                /* Specify what module code is generated. */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -57,7 +57,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
@@ -67,7 +67,7 @@
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
     // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
 
@@ -92,10 +92,10 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    "exactOptionalPropertyTypes": false,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */


### PR DESCRIPTION
This PR slightly improves type tests (as well as type definitions) and updates `tstyche` to latest beta. The release notes are here: https://tstyche.org/releases/tstyche-5

---

I would recommend testing types using most challenging compiler option. For instance, enabling `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` reveals some issues with type definitions. I have fixed these, of course.

Might be enabling these options was not possible with `tstyche@4.3.0`. It was checking source files using the same TSConfig. That is too much, because `tsc` does that job already. This behaviour is removed in TSTyche 5. Now only the `.d.ts` files are checked.

I would also recommend avoiding brackets notation when testing types of properties. The brackets notation does not allow checking wherever a property is marker optional or readonly. And it adds `| undefined` to type of each property. Try playing with the `AsyncMessage` type (that I had to fix after refactoring the test).

---

And final news! The `.tobeCallableWith()` matcher now can be used to test types as per your request (https://github.com/tstyche/tstyche/issues/592). This change was just published today (not yet documented, I was rushing because of my vacation).

The following example you provided, now works as expected:

```ts
expect<EnqueueFn<(arg: string) => string>>().type.toBeCallableWith("hello");
expect<EnqueueFn<(arg: number) => string>>().type.toBeCallableWith(1);
expect<EnqueueFn>().type.toBeCallableWith();
```

Not included in this PR. Left it for you to try out (;